### PR TITLE
Use relative paths in configs

### DIFF
--- a/conf/data/ade_data.yaml
+++ b/conf/data/ade_data.yaml
@@ -1,12 +1,12 @@
 # @package _global_
 
 num_workers: 8
-dataset_name: '/home/martinez/rebel/ade.py'
+dataset_name: 'datasets/ade.py'
 text_column: 'context'
 target_column: 'triplets'
-train_file: '/home/martinez/rebel/data/ade/ade_split_0_train.json'
-validation_file: '/home/martinez/rebel/data/ade/ade_split_0_test.json'
-test_file: '/home/martinez/rebel/data/ade/ade_split_0_test.json'
+train_file: 'data/ade/ade_split_0_train.json'
+validation_file: 'data/ade/ade_split_0_test.json'
+test_file: 'data/ade/ade_split_0_test.json'
 overwrite_cache: False
 preprocessing_num_workers: 
 max_source_length: 1024

--- a/conf/data/conll04_data.yaml
+++ b/conf/data/conll04_data.yaml
@@ -1,12 +1,12 @@
 # @package _global_
 
 num_workers: 8
-dataset_name: '/home/martinez/rebel/datasets/conll04_typed.py'
+dataset_name: 'datasets/conll04_typed.py'
 text_column: 'context'
 target_column: 'triplets'
-train_file: '/home/martinez/rebel/data/conll04/conll04_train.json'
-validation_file: '/home/martinez/rebel/data/conll04/conll04_dev.json'
-test_file: '/home/martinez/rebel/data/conll04/conll04_test.json'
+train_file: 'data/conll04/conll04_train.json'
+validation_file: 'data/conll04/conll04_dev.json'
+test_file: 'data/conll04/conll04_test.json'
 overwrite_cache: False
 preprocessing_num_workers: 
 max_source_length: 1024

--- a/conf/data/default_data.yaml
+++ b/conf/data/default_data.yaml
@@ -1,12 +1,12 @@
 # @package _global_
 
 num_workers: 8
-dataset_name: '/home/martinez/rebel/datasets/rebel-short.py'
+dataset_name: 'datasets/rebel-short.py'
 text_column: 'context'
 target_column: 'triplets'
-train_file: '/home/martinez/rebel/data/rebel/en_train.jsonl'
-validation_file: '/home/martinez/rebel/data/rebel/en_val.jsonl'
-test_file: '/home/martinez/rebel/data/rebel/en_test.jsonl'
+train_file: 'data/rebel/en_train.jsonl'
+validation_file: 'data/rebel/en_val.jsonl'
+test_file: 'data/rebel/en_test.jsonl'
 overwrite_cache: False
 preprocessing_num_workers: 
 max_source_length: 256
@@ -20,4 +20,4 @@ num_beams:
 eval_beams: 3
 ignore_pad_token_for_loss: True
 source_prefix: 
-relations_file: '/home/martinez/rebel/data/relations_count.tsv'
+relations_file: 'data/relations_count.tsv'

--- a/conf/data/docred_data.yaml
+++ b/conf/data/docred_data.yaml
@@ -1,12 +1,12 @@
 # @package _global_
 
 num_workers: 6
-dataset_name: '/home/martinez/rebel/docred_typed.py'
+dataset_name: 'datasets/docred_typed.py'
 text_column: 'context'
 target_column: 'triplets'
-train_file: '/home/martinez/rebel/data/docred_joint/train_joint.json'
-validation_file: '/home/martinez/rebel/data/docred_joint/dev_joint.json'
-test_file: '/home/martinez/rebel/data/docred_joint/test_joint.json'
+train_file: 'data/docred_joint/train_joint.json'
+validation_file: 'data/docred_joint/dev_joint.json'
+test_file: 'data/docred_joint/test_joint.json'
 overwrite_cache: False
 preprocessing_num_workers: 
 max_source_length: 1024

--- a/conf/data/nyt_data.yaml
+++ b/conf/data/nyt_data.yaml
@@ -1,12 +1,12 @@
 # @package _global_
 
 num_workers: 8
-dataset_name: '/home/martinez/rebel/datasets/nyt_typed.py'
+dataset_name: 'datasets/nyt_typed.py'
 text_column: 'context'
 target_column: 'triplets'
-train_file: '/home/martinez/rebel/data/nyt/train.json'
-validation_file: '/home/martinez/rebel/data/nyt/dev.json'
-test_file: '/home/martinez/rebel/data/nyt/test.json'
+train_file: 'data/nyt/train.json'
+validation_file: 'data/nyt/dev.json'
+test_file: 'data/nyt/test.json'
 overwrite_cache: False
 preprocessing_num_workers: 
 max_source_length: 1024

--- a/conf/data/tacred_data.yaml
+++ b/conf/data/tacred_data.yaml
@@ -1,12 +1,12 @@
 # @package _global_
 
 num_workers: 8
-dataset_name: '/home/martinez/rebel/datasets/tacred-punct.py'
+dataset_name: 'datasets/tacred-punct.py'
 text_column: 'context'
 target_column: 'triplets'
-train_file: '/home/martinez/rebel/data/tacred/data/json_re/train.json'
-validation_file: '/home/martinez/rebel/data/tacred/data/json_re/dev.json'
-test_file: '/home/martinez/rebel/data/tacred/data/json_re/test.json'
+train_file: 'data/tacred/data/json_re/train.json'
+validation_file: 'data/tacred/data/json_re/dev.json'
+test_file: 'data/tacred/data/json_re/test.json'
 overwrite_cache: False
 preprocessing_num_workers: 
 max_source_length: 1024
@@ -20,4 +20,4 @@ num_beams:
 eval_beams: 3
 ignore_pad_token_for_loss: True
 source_prefix: 
-relations_file: False
+relations_file:

--- a/conf/model/rebel_model.yaml
+++ b/conf/model/rebel_model.yaml
@@ -1,8 +1,8 @@
 # @package _global_
 
-model_name_or_path: '/home/martinez/rebel/model/Rebel-large'
-config_name: '/home/martinez/rebel/model/Rebel-large'
-tokenizer_name: '/home/martinez/rebel/model/Rebel-large'
+model_name_or_path: 'model/Rebel-large'
+config_name: 'model/Rebel-large'
+tokenizer_name: 'model/Rebel-large'
 cache_dir: 
 use_fast_tokenizer: True
 


### PR DESCRIPTION
## Summary
- reference datasets and model files relative to repo
- use local relations file in configs
- remove unused absolute path data entries

## Testing
- `pytest -q` *(fails: command not found)*